### PR TITLE
Check config_wifi_ecbm_mode_change param for ECBM notification

### DIFF
--- a/service/java/com/android/server/wifi/WifiServiceImpl.java
+++ b/service/java/com/android/server/wifi/WifiServiceImpl.java
@@ -1430,8 +1430,10 @@ public final class WifiServiceImpl extends IWifiManager.Stub {
         intentFilter.addAction(WifiManager.NETWORK_STATE_CHANGED_ACTION);
         intentFilter.addAction(WifiManager.WIFI_AP_STATE_CHANGED_ACTION);
         intentFilter.addAction(BluetoothAdapter.ACTION_CONNECTION_STATE_CHANGED);
-        intentFilter.addAction(TelephonyIntents.ACTION_EMERGENCY_CALLBACK_MODE_CHANGED);
         intentFilter.addAction(PowerManager.ACTION_DEVICE_IDLE_MODE_CHANGED);
+        if(mContext.getResources().getBoolean(R.bool.config_wifi_ecbm_mode_change)) {
+            intentFilter.addAction(TelephonyIntents.ACTION_EMERGENCY_CALLBACK_MODE_CHANGED);
+        }
         mContext.registerReceiver(mReceiver, intentFilter);
     }
 


### PR DESCRIPTION
Wi-Fi module detection on ECBM mode change is controlled by this
configuration parameter. Hence check for this configuration parameter
before registering for indication.

CRs-Fixed: 903365
Change-Id: Ib1eb4bf03262158f805ffac959f8f9b12b80e659
